### PR TITLE
Fix typo in Nations.JSON and update English translation file

### DIFF
--- a/jsons/Nations.json
+++ b/jsons/Nations.json
@@ -603,7 +603,7 @@
 		"innerColor": [156, 37, 37],
 		"favoredReligion": "Voidist",
 		"uniqueName": "The Hounds of War",
-		"uniques": ["Earn [50]% of killed [Military] unit's [Strength] as [Culture]","[+30]% Strength <vs [City-states]>"],
+		"uniques": ["Earn [50]% of killed [Military] unit's [Strength] as [Culture]","[+30]% Strength <vs [City-States]>"],
 		"cities": [
 			"Ragnarok's Fist",
 			"Jotunheim",

--- a/jsons/translations/English.properties
+++ b/jsons/translations/English.properties
@@ -138,7 +138,8 @@ Cannot gain more XP from Barbarians = Cannot gain more XP from Xenos
 50% chance of capturing defeated Barbarian naval units and earning 25 Gold = 50% chance of capturing defeated naval Xenos units and earning a bounty of 25 Credits
 Receive triple Gold from Barbarian encampments and pillaging Cities = Receive triple amount of Credits from clearing Xeno Hives and pillaging Cities
 
-When conquering an encampment, earn [amount] Gold and recruit a Barbarian unit = When clearing a Hive, earn [amount] Gold and control a Xeno unit
+When conquering an encampment, earn [amount] Gold and recruit a Barbarian unit = When clearing a Hive, earn [amount] Credits and control a Xeno unit
+When defeating a [mapUnitFilter] unit, earn [amount] Gold and recruit it = When defeating a [mapUnitFilter] unit, earn [amount] Credits and recruit it
 
 Notified of new Barbarian encampments = Notified of new Xeno Hives
 


### PR DESCRIPTION
This fixes Einherjar Diktat's unique so that it will properly give the bonus against City-States. This also updates the English translation file to say "Credits" instead of "Gold" in the two uniques related to recruiting units.