### PR TITLE
remove unit-consuming construction of water improvements

### DIFF
--- a/jsons/Units.json
+++ b/jsons/Units.json
@@ -631,7 +631,7 @@
 		"uniques": [
 			"Worker",
 			"Can build [Land] improvements on tiles",
-			"May create improvements on water resources",
+			//"May create improvements on water resources",
 			"Can build [Water] improvements on tiles",
 			//"Can instantly construct a [Water] improvement <for [2] movement>"
 		],


### PR DESCRIPTION
automated units use this instead of normal construction, forcing player to rebuild workers, which is bad